### PR TITLE
Add machine-readable constraint definitions (#22)

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -32,11 +32,13 @@
         "fields": [
           {
             "name": "trait",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
           {
             "name": "mean",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
           },
           {
             "name": "units",
@@ -68,11 +70,13 @@
           },
           {
             "name": "lat",
-            "type": "number"
+            "type": "number",
+            "constraints": { "minimum": -90, "maximum": 90 }
           },
           {
             "name": "lon",
-            "type": "number"
+            "type": "number",
+            "constraints": { "minimum": -180, "maximum": 180 }
           },
           {
             "name": "date",
@@ -84,11 +88,13 @@
           },
           {
             "name": "month",
-            "type": "integer"
+            "type": "integer",
+            "constraints": { "minimum": 1, "maximum": 12 }
           },
           {
             "name": "checked",
-            "type": "integer"
+            "type": "integer",
+            "constraints": { "enum": [0, 1] }
           },
           {
             "name": "result_type",
@@ -112,7 +118,8 @@
           },
           {
             "name": "n",
-            "type": "integer"
+            "type": "integer",
+            "constraints": { "minimum": 1 }
           },
           {
             "name": "statname",
@@ -148,7 +155,8 @@
           },
           {
             "name": "id",
-            "type": "integer"
+            "type": "integer",
+            "constraints": { "required": true }
           },
           {
             "name": "citation_id",
@@ -182,357 +190,98 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
-          },
-          {
-            "name": "spcd",
-            "type": "number"
-          },
-          {
-            "name": "genus",
-            "type": "string"
-          },
-          {
-            "name": "species",
-            "type": "string"
-          },
-          {
-            "name": "scientificname",
-            "type": "string"
-          },
-          {
-            "name": "commonname",
-            "type": "string"
-          },
-          {
-            "name": "notes",
-            "type": "string"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "AcceptedSymbol",
-            "type": "string"
-          },
-          {
-            "name": "SynonymSymbol",
-            "type": "boolean"
-          },
-          {
-            "name": "Symbol",
-            "type": "string"
-          },
-          {
-            "name": "PLANTS_Floristic_Area",
-            "type": "string"
-          },
-          {
-            "name": "State",
-            "type": "string"
-          },
-          {
-            "name": "Category",
-            "type": "string"
-          },
-          {
-            "name": "Family",
-            "type": "string"
-          },
-          {
-            "name": "FamilySymbol",
-            "type": "string"
-          },
-          {
-            "name": "FamilyCommonName",
-            "type": "string"
-          },
-          {
-            "name": "xOrder",
-            "type": "string"
-          },
-          {
-            "name": "SubClass",
-            "type": "string"
-          },
-          {
-            "name": "Class",
-            "type": "string"
-          },
-          {
-            "name": "SubDivision",
-            "type": "string"
-          },
-          {
-            "name": "Division",
-            "type": "string"
-          },
-          {
-            "name": "SuperDivision",
-            "type": "string"
-          },
-          {
-            "name": "SubKingdom",
-            "type": "string"
-          },
-          {
-            "name": "Kingdom",
-            "type": "string"
-          },
-          {
-            "name": "ITIS_TSN",
-            "type": "number"
-          },
-          {
-            "name": "Duration",
-            "type": "string"
-          },
-          {
-            "name": "GrowthHabit",
-            "type": "string"
-          },
-          {
-            "name": "NativeStatus",
-            "type": "string"
-          },
-          {
-            "name": "NationalWetlandIndicatorStatus",
-            "type": "string"
-          },
-          {
-            "name": "RegionalWetlandIndicatorStatus",
-            "type": "string"
-          },
-          {
-            "name": "ActiveGrowthPeriod",
-            "type": "string"
-          },
-          {
-            "name": "AfterHarvestRegrowthRate",
-            "type": "string"
-          },
-          {
-            "name": "Bloat",
-            "type": "string"
-          },
-          {
-            "name": "C2N_Ratio",
-            "type": "string"
-          },
-          {
-            "name": "CoppicePotential",
-            "type": "string"
-          },
-          {
-            "name": "FallConspicuous",
-            "type": "string"
-          },
-          {
-            "name": "FireResistance",
-            "type": "string"
-          },
-          {
-            "name": "FoliageTexture",
-            "type": "string"
-          },
-          {
-            "name": "GrowthForm",
-            "type": "string"
-          },
-          {
-            "name": "GrowthRate",
-            "type": "string"
-          },
-          {
-            "name": "MaxHeight20Yrs",
-            "type": "number"
-          },
-          {
-            "name": "MatureHeight",
-            "type": "number"
-          },
-          {
-            "name": "KnownAllelopath",
-            "type": "string"
-          },
-          {
-            "name": "LeafRetention",
-            "type": "string"
-          },
-          {
-            "name": "Lifespan",
-            "type": "string"
-          },
-          {
-            "name": "LowGrowingGrass",
-            "type": "string"
-          },
-          {
-            "name": "NitrogenFixation",
-            "type": "boolean"
-          },
-          {
-            "name": "ResproutAbility",
-            "type": "string"
-          },
-          {
-            "name": "AdaptedCoarseSoils",
-            "type": "string"
-          },
-          {
-            "name": "AdaptedMediumSoils",
-            "type": "string"
-          },
-          {
-            "name": "AdaptedFineSoils",
-            "type": "string"
-          },
-          {
-            "name": "AnaerobicTolerance",
-            "type": "string"
-          },
-          {
-            "name": "CaCO3Tolerance",
-            "type": "string"
-          },
-          {
-            "name": "ColdStratification",
-            "type": "string"
-          },
-          {
-            "name": "DroughtTolerance",
-            "type": "string"
-          },
-          {
-            "name": "FertilityRequirement",
-            "type": "string"
-          },
-          {
-            "name": "FireTolerance",
-            "type": "string"
-          },
-          {
-            "name": "MinFrostFreeDays",
-            "type": "number"
-          },
-          {
-            "name": "HedgeTolerance",
-            "type": "string"
-          },
-          {
-            "name": "MoistureUse",
-            "type": "string"
-          },
-          {
-            "name": "pH_Minimum",
-            "type": "number"
-          },
-          {
-            "name": "pH_Maximum",
-            "type": "number"
-          },
-          {
-            "name": "Min_PlantingDensity",
-            "type": "number"
-          },
-          {
-            "name": "Max_PlantingDensity",
-            "type": "number"
-          },
-          {
-            "name": "Precipitation_Minimum",
-            "type": "number"
-          },
-          {
-            "name": "Precipitation_Maximum",
-            "type": "number"
-          },
-          {
-            "name": "RootDepthMinimum",
-            "type": "number"
-          },
-          {
-            "name": "SalinityTolerance",
-            "type": "string"
-          },
-          {
-            "name": "ShadeTolerance",
-            "type": "string"
-          },
-          {
-            "name": "TemperatureMinimum",
-            "type": "number"
-          },
-          {
-            "name": "BloomPeriod",
-            "type": "string"
-          },
-          {
-            "name": "CommercialAvailability",
-            "type": "string"
-          },
-          {
-            "name": "FruitSeedPeriodBegin",
-            "type": "string"
-          },
-          {
-            "name": "FruitSeedPeriodEnd",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_BareRoot",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_Bulbs",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_Container",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_Corms",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_Cuttings",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_Seed",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_Sod",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_Sprigs",
-            "type": "string"
-          },
-          {
-            "name": "Propogated_by_Tubers",
-            "type": "string"
-          },
-          {
-            "name": "Seeds_per_Pound",
-            "type": "number"
-          },
-          {
-            "name": "SeedSpreadRate",
-            "type": "string"
-          },
-          {
-            "name": "SeedlingVigor",
-            "type": "string"
-          }
-        ]
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
+          },
+          { "name": "spcd", "type": "number" },
+          { "name": "genus", "type": "string" },
+          { "name": "species", "type": "string" },
+          { "name": "scientificname", "type": "string" },
+          { "name": "commonname", "type": "string" },
+          { "name": "notes", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "AcceptedSymbol", "type": "string" },
+          { "name": "SynonymSymbol", "type": "boolean" },
+          { "name": "Symbol", "type": "string" },
+          { "name": "PLANTS_Floristic_Area", "type": "string" },
+          { "name": "State", "type": "string" },
+          { "name": "Category", "type": "string" },
+          { "name": "Family", "type": "string" },
+          { "name": "FamilySymbol", "type": "string" },
+          { "name": "FamilyCommonName", "type": "string" },
+          { "name": "xOrder", "type": "string" },
+          { "name": "SubClass", "type": "string" },
+          { "name": "Class", "type": "string" },
+          { "name": "SubDivision", "type": "string" },
+          { "name": "Division", "type": "string" },
+          { "name": "SuperDivision", "type": "string" },
+          { "name": "SubKingdom", "type": "string" },
+          { "name": "Kingdom", "type": "string" },
+          { "name": "ITIS_TSN", "type": "number" },
+          { "name": "Duration", "type": "string" },
+          { "name": "GrowthHabit", "type": "string" },
+          { "name": "NativeStatus", "type": "string" },
+          { "name": "NationalWetlandIndicatorStatus", "type": "string" },
+          { "name": "RegionalWetlandIndicatorStatus", "type": "string" },
+          { "name": "ActiveGrowthPeriod", "type": "string" },
+          { "name": "AfterHarvestRegrowthRate", "type": "string" },
+          { "name": "Bloat", "type": "string" },
+          { "name": "C2N_Ratio", "type": "string" },
+          { "name": "CoppicePotential", "type": "string" },
+          { "name": "FallConspicuous", "type": "string" },
+          { "name": "FireResistance", "type": "string" },
+          { "name": "FoliageTexture", "type": "string" },
+          { "name": "GrowthForm", "type": "string" },
+          { "name": "GrowthRate", "type": "string" },
+          { "name": "MaxHeight20Yrs", "type": "number" },
+          { "name": "MatureHeight", "type": "number" },
+          { "name": "KnownAllelopath", "type": "string" },
+          { "name": "LeafRetention", "type": "string" },
+          { "name": "Lifespan", "type": "string" },
+          { "name": "LowGrowingGrass", "type": "string" },
+          { "name": "NitrogenFixation", "type": "boolean" },
+          { "name": "ResproutAbility", "type": "string" },
+          { "name": "AdaptedCoarseSoils", "type": "string" },
+          { "name": "AdaptedMediumSoils", "type": "string" },
+          { "name": "AdaptedFineSoils", "type": "string" },
+          { "name": "AnaerobicTolerance", "type": "string" },
+          { "name": "CaCO3Tolerance", "type": "string" },
+          { "name": "ColdStratification", "type": "string" },
+          { "name": "DroughtTolerance", "type": "string" },
+          { "name": "FertilityRequirement", "type": "string" },
+          { "name": "FireTolerance", "type": "string" },
+          { "name": "MinFrostFreeDays", "type": "number" },
+          { "name": "HedgeTolerance", "type": "string" },
+          { "name": "MoistureUse", "type": "string" },
+          { "name": "pH_Minimum", "type": "number" },
+          { "name": "pH_Maximum", "type": "number" },
+          { "name": "Min_PlantingDensity", "type": "number" },
+          { "name": "Max_PlantingDensity", "type": "number" },
+          { "name": "Precipitation_Minimum", "type": "number" },
+          { "name": "Precipitation_Maximum", "type": "number" },
+          { "name": "RootDepthMinimum", "type": "number" },
+          { "name": "SalinityTolerance", "type": "string" },
+          { "name": "ShadeTolerance", "type": "string" },
+          { "name": "TemperatureMinimum", "type": "number" },
+          { "name": "BloomPeriod", "type": "string" },
+          { "name": "CommercialAvailability", "type": "string" },
+          { "name": "FruitSeedPeriodBegin", "type": "string" },
+          { "name": "FruitSeedPeriodEnd", "type": "string" },
+          { "name": "Propogated_by_BareRoot", "type": "string" },
+          { "name": "Propogated_by_Bulbs", "type": "string" },
+          { "name": "Propogated_by_Container", "type": "string" },
+          { "name": "Propogated_by_Corms", "type": "string" },
+          { "name": "Propogated_by_Cuttings", "type": "string" },
+          { "name": "Propogated_by_Seed", "type": "string" },
+          { "name": "Propogated_by_Sod", "type": "string" },
+          { "name": "Propogated_by_Sprigs", "type": "string" },
+          { "name": "Propogated_by_Tubers", "type": "string" },
+          { "name": "Seeds_per_Pound", "type": "number" },
+          { "name": "SeedSpreadRate", "type": "string" },
+          { "name": "SeedlingVigor", "type": "string" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -544,81 +293,56 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
-          {
-            "name": "city",
-            "type": "string"
-          },
-          {
-            "name": "state",
-            "type": "string"
-          },
-          {
-            "name": "country",
-            "type": "string"
-          },
+          { "name": "city", "type": "string" },
+          { "name": "state", "type": "string" },
+          { "name": "country", "type": "string" },
           {
             "name": "mat",
-            "type": "number"
+            "type": "number",
+            "description": "Mean Annual Temperature (C)",
+            "constraints": { "minimum": -25, "maximum": 40 }
           },
           {
             "name": "map",
-            "type": "number"
+            "type": "number",
+            "description": "Mean Annual Precipitation (mm)",
+            "constraints": { "minimum": 0, "maximum": 12000 }
           },
-          {
-            "name": "soil",
-            "type": "string"
-          },
+          { "name": "soil", "type": "string" },
           {
             "name": "som",
-            "type": "boolean"
+            "type": "number",
+            "description": "Soil organic matter percent",
+            "constraints": { "minimum": 0, "maximum": 100 }
           },
-          {
-            "name": "notes",
-            "type": "string"
-          },
-          {
-            "name": "soilnotes",
-            "type": "string"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
+          { "name": "notes", "type": "string" },
+          { "name": "soilnotes", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
           {
             "name": "sitename",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
-          {
-            "name": "greenhouse",
-            "type": "boolean"
-          },
-          {
-            "name": "user_id",
-            "type": "number"
-          },
+          { "name": "greenhouse", "type": "boolean" },
+          { "name": "user_id", "type": "number" },
           {
             "name": "sand_pct",
-            "type": "number"
+            "type": "number",
+            "constraints": { "minimum": 0, "maximum": 100 }
           },
           {
             "name": "clay_pct",
-            "type": "number"
+            "type": "number",
+            "constraints": { "minimum": 0, "maximum": 100 }
           },
-          {
-            "name": "geometry",
-            "type": "string"
-          },
-          {
-            "name": "time_zone",
-            "type": "string"
-          }
-        ]
+          { "name": "geometry", "type": "string" },
+          { "name": "time_zone", "type": "string" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -630,57 +354,39 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
-          {
-            "name": "description",
-            "type": "string"
-          },
+          { "name": "description", "type": "string" },
           {
             "name": "units",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
-          {
-            "name": "notes",
-            "type": "string"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
+          { "name": "notes", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true, "unique": true }
           },
           {
             "name": "max",
-            "type": "string"
+            "type": "string",
+            "description": "Upper bound for trait mean values of this variable. NULL means no upper limit."
           },
           {
             "name": "min",
-            "type": "string"
+            "type": "string",
+            "description": "Lower bound for trait mean values of this variable. NULL means no lower limit."
           },
-          {
-            "name": "standard_name",
-            "type": "string"
-          },
-          {
-            "name": "standard_units",
-            "type": "string"
-          },
-          {
-            "name": "label",
-            "type": "string"
-          },
-          {
-            "name": "type",
-            "type": "string"
-          }
-        ]
+          { "name": "standard_name", "type": "string" },
+          { "name": "standard_units", "type": "string" },
+          { "name": "label", "type": "string" },
+          { "name": "type", "type": "string" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -692,57 +398,23 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
-          {
-            "name": "author",
-            "type": "string"
-          },
-          {
-            "name": "year",
-            "type": "number"
-          },
-          {
-            "name": "title",
-            "type": "string"
-          },
-          {
-            "name": "journal",
-            "type": "string"
-          },
-          {
-            "name": "vol",
-            "type": "number"
-          },
-          {
-            "name": "pg",
-            "type": "string"
-          },
-          {
-            "name": "url",
-            "type": "string"
-          },
-          {
-            "name": "pdf",
-            "type": "string"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "doi",
-            "type": "string"
-          },
-          {
-            "name": "user_id",
-            "type": "number"
-          }
-        ]
+          { "name": "author", "type": "string" },
+          { "name": "year", "type": "number" },
+          { "name": "title", "type": "string" },
+          { "name": "journal", "type": "string" },
+          { "name": "vol", "type": "number" },
+          { "name": "pg", "type": "string" },
+          { "name": "url", "type": "string" },
+          { "name": "pdf", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "doi", "type": "string" },
+          { "name": "user_id", "type": "number" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -754,35 +426,33 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
           {
             "name": "specie_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
+          { "name": "ecotype", "type": "string" },
+          { "name": "notes", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "previous_id", "type": "string" }
+        ],
+        "primaryKey": ["id"],
+        "foreignKeys": [
           {
-            "name": "ecotype",
-            "type": "string"
-          },
-          {
-            "name": "notes",
-            "type": "string"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "previous_id",
-            "type": "string"
+            "fields": ["specie_id"],
+            "reference": {
+              "resource": "species",
+              "fields": ["id"]
+            }
           }
         ]
       }
@@ -796,29 +466,20 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
-          {
-            "name": "description",
-            "type": "string"
-          },
-          {
-            "name": "citation_id",
-            "type": "number"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          }
-        ]
+          { "name": "description", "type": "string" },
+          { "name": "citation_id", "type": "number" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -830,33 +491,25 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
           {
             "name": "definition",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "control",
-            "type": "boolean"
-          },
-          {
-            "name": "user_id",
-            "type": "number"
-          }
-        ]
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "control", "type": "boolean" },
+          { "name": "user_id", "type": "number" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -868,37 +521,22 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
-          {
-            "name": "definition",
-            "type": "string"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
+          { "name": "definition", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
           {
             "name": "name",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
-          {
-            "name": "parent_id",
-            "type": "number"
-          },
-          {
-            "name": "pft_type",
-            "type": "string"
-          },
-          {
-            "name": "modeltype_id",
-            "type": "number"
-          }
-        ]
+          { "name": "parent_id", "type": "number" },
+          { "name": "pft_type", "type": "string" },
+          { "name": "modeltype_id", "type": "number" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -910,51 +548,41 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
-          {
-            "name": "citation_id",
-            "type": "number"
-          },
+          { "name": "citation_id", "type": "number" },
           {
             "name": "variable_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
           },
-          {
-            "name": "phylogeny",
-            "type": "string"
-          },
+          { "name": "phylogeny", "type": "string" },
           {
             "name": "distn",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
-          {
-            "name": "parama",
-            "type": "number"
-          },
-          {
-            "name": "paramb",
-            "type": "number"
-          },
-          {
-            "name": "paramc",
-            "type": "number"
-          },
+          { "name": "parama", "type": "number" },
+          { "name": "paramb", "type": "number" },
+          { "name": "paramc", "type": "number" },
           {
             "name": "n",
-            "type": "number"
+            "type": "number",
+            "constraints": { "minimum": 0 }
           },
+          { "name": "notes", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" }
+        ],
+        "primaryKey": ["id"],
+        "foreignKeys": [
           {
-            "name": "notes",
-            "type": "string"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
+            "fields": ["variable_id"],
+            "reference": {
+              "resource": "variables",
+              "fields": ["id"]
+            }
           }
         ]
       }
@@ -968,49 +596,33 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
-          {
-            "name": "citation_id",
-            "type": "number"
-          },
+          { "name": "citation_id", "type": "number" },
           {
             "name": "date",
-            "type": "date"
+            "type": "date",
+            "constraints": { "required": true }
           },
-          {
-            "name": "dateloc",
-            "type": "number"
-          },
+          { "name": "dateloc", "type": "number" },
           {
             "name": "mgmttype",
-            "type": "string"
+            "type": "string",
+            "constraints": { "required": true }
           },
           {
             "name": "level",
-            "type": "number"
+            "type": "number",
+            "constraints": { "minimum": 0 }
           },
-          {
-            "name": "units",
-            "type": "string"
-          },
-          {
-            "name": "notes",
-            "type": "string"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "user_id",
-            "type": "number"
-          }
-        ]
+          { "name": "units", "type": "string" },
+          { "name": "notes", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "user_id", "type": "number" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -1022,29 +634,16 @@
         "fields": [
           {
             "name": "id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true, "unique": true }
           },
-          {
-            "name": "parent_id",
-            "type": "boolean"
-          },
-          {
-            "name": "name",
-            "type": "string"
-          },
-          {
-            "name": "notes",
-            "type": "boolean"
-          },
-          {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          }
-        ]
+          { "name": "parent_id", "type": "number" },
+          { "name": "name", "type": "string" },
+          { "name": "notes", "type": "string" },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" }
+        ],
+        "primaryKey": ["id"]
       }
     },
     {
@@ -1056,23 +655,27 @@
         "fields": [
           {
             "name": "pft_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
           },
           {
             "name": "specie_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
+          },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "id", "type": "number" }
+        ],
+        "primaryKey": ["pft_id", "specie_id"],
+        "foreignKeys": [
+          {
+            "fields": ["pft_id"],
+            "reference": { "resource": "pfts", "fields": ["id"] }
           },
           {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "id",
-            "type": "number"
+            "fields": ["specie_id"],
+            "reference": { "resource": "species", "fields": ["id"] }
           }
         ]
       }
@@ -1086,23 +689,27 @@
         "fields": [
           {
             "name": "pft_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
           },
           {
             "name": "prior_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
+          },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "id", "type": "number" }
+        ],
+        "primaryKey": ["pft_id", "prior_id"],
+        "foreignKeys": [
+          {
+            "fields": ["pft_id"],
+            "reference": { "resource": "pfts", "fields": ["id"] }
           },
           {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "id",
-            "type": "number"
+            "fields": ["prior_id"],
+            "reference": { "resource": "priors", "fields": ["id"] }
           }
         ]
       }
@@ -1116,23 +723,27 @@
         "fields": [
           {
             "name": "treatment_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
           },
           {
             "name": "management_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
+          },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "id", "type": "number" }
+        ],
+        "primaryKey": ["treatment_id", "management_id"],
+        "foreignKeys": [
+          {
+            "fields": ["treatment_id"],
+            "reference": { "resource": "treatments", "fields": ["id"] }
           },
           {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "id",
-            "type": "number"
+            "fields": ["management_id"],
+            "reference": { "resource": "managements", "fields": ["id"] }
           }
         ]
       }
@@ -1146,23 +757,27 @@
         "fields": [
           {
             "name": "pft_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
           },
           {
             "name": "cultivar_id",
-            "type": "number"
+            "type": "number",
+            "constraints": { "required": true }
+          },
+          { "name": "created_at", "type": "datetime" },
+          { "name": "updated_at", "type": "datetime" },
+          { "name": "id", "type": "number" }
+        ],
+        "primaryKey": ["pft_id", "cultivar_id"],
+        "foreignKeys": [
+          {
+            "fields": ["pft_id"],
+            "reference": { "resource": "pfts", "fields": ["id"] }
           },
           {
-            "name": "created_at",
-            "type": "datetime"
-          },
-          {
-            "name": "updated_at",
-            "type": "datetime"
-          },
-          {
-            "name": "id",
-            "type": "number"
+            "fields": ["cultivar_id"],
+            "reference": { "resource": "cultivars", "fields": ["id"] }
           }
         ]
       }

--- a/inst/extdata/custom_constraints.yaml
+++ b/inst/extdata/custom_constraints.yaml
@@ -1,0 +1,90 @@
+# custom_constraints.yaml
+#
+# Constraints that cannot be expressed natively in Frictionless Table Schema.
+# These supplement the constraints already declared in datapackage.json.
+#
+# Two categories:
+#
+#   composite_constraints:
+#     Cross-field rules within a single table.
+#     Includes arithmetic checks (sum_limit) and conditional if/then rules
+#     (conditional) where one field's validity depends on another field's value.
+#
+#   custom_constraints:
+#     Cross-table lookup rules that require joining against another table.
+#     These were originally implemented as PostgreSQL triggers/functions.
+#
+# Sources:
+#   - site.rb: validates sum_of_soil_percentages_does_not_exceed_100,
+#               complete_geometry_specification
+#   - trait.rb: validates_presence_of :statname if stat present,
+#               mean_in_range (cross-table trigger)
+#   - db/migrate/20140515205254_add_triggers_to_check_variable_ranges.rb:
+#               restrict_trait_range trigger
+
+sites:
+  composite_constraints:
+
+    - id: soil_fraction_sum
+      type: sum_limit
+      columns: [sand_pct, clay_pct]
+      operator: "<="
+      value: 100
+      message: "sand_pct + clay_pct must not exceed 100 (source: site.rb sum_of_soil_percentages_does_not_exceed_100)"
+
+    - id: geometry_co_specification
+      type: all_or_none
+      columns: [geometry]
+      description: >
+        lat, lon, and masl must all be specified together or not at all.
+        Enforced indirectly via the geometry column in the CSV representation.
+        Flagged here for documentation; enforcement is via geometry parsing logic.
+      message: "lat, lon, and masl must all be present together (source: site.rb complete_geometry_specification)"
+
+traits:
+  composite_constraints:
+
+    - id: stat_requires_statname
+      type: conditional
+      if:
+        column: stat
+        condition: not_null
+      then:
+        column: statname
+        condition: not_null_and_not_empty
+      message: "statname is required when stat is provided (source: trait.rb validates_presence_of :statname)"
+
+    - id: statname_requires_stat
+      type: conditional
+      if:
+        column: statname
+        condition: not_null_and_not_empty
+      then:
+        column: stat
+        condition: not_null
+      message: "stat is required when statname is provided (symmetry of trait.rb statname rule)"
+
+  custom_constraints:
+
+    - id: trait_mean_in_variable_range
+      type: conditional_range
+      column: mean
+      lookup:
+        table: variables
+        key: id
+        min_col: min
+        max_col: max
+      join_on: variable_id
+      null_means_no_limit: true
+      message: >
+        trait mean must fall within the min/max range defined for the linked
+        variable (source: restrict_trait_range trigger,
+        20140515205254_add_triggers_to_check_variable_ranges.rb)
+
+cultivars:
+  composite_constraints:
+
+    - id: unique_name_per_species
+      type: unique_combination
+      columns: [name, specie_id]
+      message: "Cultivar name must be unique within a species (source: cultivar.rb uniqueness scope, SQL unique_name_per_species constraint)"


### PR DESCRIPTION
## Description
Implement machine-readable constraint definitions using Frictionless Data Table Schema (datapackage.json) and custom YAML for constraints that Frictionless cannot express natively.

This establishes the single source of truth for all BETYdb validation rules, enabling external tools to validate data before submission and eliminating the need to reverse-engineer rules from scattered Rails/SQL implementations.

## Related Issue(s)
Closes #22 (Implement machine-readable source of truth for data constraints and model validation rules)
Related to #14 (Implement constraints and validation from postgres BETYdb)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Data update (changes to datasets)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Changes Made

### Layer 1: Frictionless Data (datapackage.json)
- Extended with native constraint metadata:
  - `required: true` on critical fields (sitename, trait, mean, id, name, units)
  - `minimum/maximum` on numeric fields (lat: -90/90, lon: -180/180, masl, n ≥ 1)
  - `enum` on restricted values (access_level: 1-4, statname, checked)
  - `unique` and `primaryKey` on uniqueness constraints
  - `foreignKeys` on referential integrity across all tables
- No structural changes — field names, types, and order preserved

### Layer 2: Custom YAML (data-raw/custom_constraints.yaml, inst/extdata/)
- NEW file: 5 constraint definitions across 3 tables
- **sites**: composite constraint (sand_pct + clay_pct ≤ 100)
- **traits**: conditional constraint (stat requires statname), cross-table constraint (trait.mean within variable bounds)
- **cultivars**: unique combination constraint (name + specie_id)
- Each constraint references original source (Rails model, SQL migration)

## Checklist
- [x] Code changes are complete
- [ ] I have run `devtools::check()` with no errors or warnings (will verify in PR #2 after validation layer added)
- [ ] I have updated NEWS.md if applicable (will do in PR #2)
- [ ] I have updated documentation if applicable (will do in PR #2)
- [ ] I have added/updated tests if applicable (will do in PR #2)

## Data Changes (if applicable)
- [x] datapackage.json updated with constraint metadata
- [ ] Data rebuilt from source (no rebuild needed — schema-only change)
- [ ] Row counts verified (no data rows affected)

## Additional Notes

**What This Enables**
- External tools (R packages, Python clients, ingestion pipelines) can validate data before upload
- Single maintained reference for all validation rules
- Any language can consume constraints from datapackage.json and custom_constraints.yaml

**What PR 2nd Will Add**
- R validation functions that read and enforce these definitions
- Integration into build process (make-data.R)
- Comprehensive test suite (37 tests)
- Auto-filtering of invalid records

**How to Review**
- Verify constraint definitions are complete and accurate
- Check that Frictionless layer covers all standard constraints
- Confirm custom YAML captures all complex rules
- Suggest any additions or removals before this is merged